### PR TITLE
Initialize src, tests, and docs layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.env

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ This repository contains a simple example project demonstrating how to integrate
 - Provide example code that can be extended into a full-featured chatbot.
 - Document setup steps and usage instructions.
 
+## Directory Structure
+
+- `src/` - application source code
+- `tests/` - unit tests
+- `docs/` - project documentation
+
 ## Getting Started
 
 1. Install dependencies with `pip install openai`.
 2. Set your API key in the `OPENAI_API_KEY` environment variable.
-3. Run the example script to interact with the chatbot.
+3. Run the example script to interact with the chatbot: `python -m src.chatbot`.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+This directory will contain detailed documentation for the project.
+
+- `src/` holds the application source code.
+- `tests/` contains test suites.
+- `docs/` stores documentation assets.

--- a/src/chatbot.py
+++ b/src/chatbot.py
@@ -1,0 +1,24 @@
+import os
+import openai
+
+def ask(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+    """Send a prompt to the OpenAI API and return the assistant's response."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY not set")
+    openai.api_key = api_key
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return response.choices[0].message["content"]
+
+
+def main() -> None:
+    prompt = input("You: ")
+    answer = ask(prompt)
+    print("Assistant:", answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import unittest
+
+# Allow import from the src directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src import chatbot
+
+
+class ChatbotTests(unittest.TestCase):
+    def test_missing_api_key(self):
+        # Ensure the environment variable is absent
+        if "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+        with self.assertRaises(EnvironmentError):
+            chatbot.ask("Hello")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restructure repository with `src/`, `tests/`, and `docs/`
- implement simple `chatbot` module
- add unit test ensuring API key presence
- document new layout and add documentation placeholder
- ignore temporary Python files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68711e84c3ac832a9eaddbb9b0c1e5cf