### PR TITLE
Update README with run and contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,33 @@ This repository contains a simple example project demonstrating how to integrate
 2. Set your API key in the `OPENAI_API_KEY` environment variable.
 3. Run the example script to interact with the chatbot: `python -m src.chatbot`.
 
+## Running the Code
+
+Once you have installed the dependencies and set your API key, start the chatbot interactively:
+
+```
+python -m src.chatbot
+```
+
+Run the test suite to verify everything works as expected:
+
+```
+python -m unittest discover tests
+```
+
+## Contributing
+
+Contributions are welcome! To contribute:
+
+1. Fork this repository and create a new branch for your feature or fix.
+2. Make your changes and commit them with clear messages.
+3. Run the tests to ensure nothing is broken.
+4. Open a pull request describing your changes.
+
+## Contact
+
+For questions or support, please open an issue on GitHub or email <open-source@example.com>.
+
 ## License
 
 This project is released under the MIT License.


### PR DESCRIPTION
## Summary
- expand README with instructions on running the chatbot
- add contributing guidelines and contact info

## Testing
- `python -m unittest discover`
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'openai')*
- `python tests/test_chatbot.py` *(fails: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_687123ed3d0c832ab263fa317c1d5e49