### PR TITLE
Add conversation history support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains a simple example project demonstrating how to integrate
 
 ## Running the Code
 
-Once you have installed the dependencies and set your API key, start the chatbot interactively:
+Once you have installed the dependencies and set your API key, start the chatbot interactively. The chat session keeps a history of your conversation until you submit an empty line to exit:
 
 ```
 python -m src.chatbot

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This directory will contain detailed documentation for the project.
+This directory will contain detailed documentation for the project. The chatbot now supports a running conversation, so example sessions will show multiple user and assistant messages.
 
 - `src/` holds the application source code.
 - `tests/` contains test suites.

--- a/src/chatbot.py
+++ b/src/chatbot.py
@@ -1,23 +1,32 @@
 import os
 import openai
+from typing import List, Dict
 
-def ask(prompt: str, model: str = "gpt-3.5-turbo") -> str:
-    """Send a prompt to the OpenAI API and return the assistant's response."""
+
+def ask(messages: List[Dict[str, str]], model: str = "gpt-3.5-turbo") -> str:
+    """Send conversation history to the OpenAI API and return the assistant's response."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise EnvironmentError("OPENAI_API_KEY not set")
     openai.api_key = api_key
     response = openai.ChatCompletion.create(
         model=model,
-        messages=[{"role": "user", "content": prompt}]
+        messages=messages
     )
     return response.choices[0].message["content"]
 
 
 def main() -> None:
-    prompt = input("You: ")
-    answer = ask(prompt)
-    print("Assistant:", answer)
+    """Start an interactive chat session maintaining conversation history."""
+    messages: List[Dict[str, str]] = []
+    while True:
+        prompt = input("You: ")
+        if not prompt:
+            break
+        messages.append({"role": "user", "content": prompt})
+        answer = ask(messages)
+        messages.append({"role": "assistant", "content": answer})
+        print("Assistant:", answer)
 
 
 if __name__ == "__main__":

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,9 +1,13 @@
 import os
 import sys
+import types
 import unittest
 
 # Allow import from the src directory
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide a minimal stub for the openai module so tests can run without the dependency
+sys.modules.setdefault('openai', types.SimpleNamespace())
 
 from src import chatbot
 
@@ -14,7 +18,7 @@ class ChatbotTests(unittest.TestCase):
         if "OPENAI_API_KEY" in os.environ:
             del os.environ["OPENAI_API_KEY"]
         with self.assertRaises(EnvironmentError):
-            chatbot.ask("Hello")
+            chatbot.ask([{"role": "user", "content": "Hello"}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the chatbot to maintain conversation history during a session
- adjust tests to work without the openai package installed
- document the conversation history feature

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_687129a733b0832a8742c6e7bd30c110