### PR TITLE
Add conversation history file option and CLI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ This repository contains a simple example project demonstrating how to integrate
 
 ## Running the Code
 
-Once you have installed the dependencies and set your API key, start the chatbot interactively. The chat session keeps a history of your conversation until you submit an empty line to exit:
+Once you have installed the dependencies and set your API key, start the chatbot interactively. You can optionally choose the model, adjust the temperature, and
+store the conversation in a file. The session continues until you submit an empty line to exit:
 
 ```
-python -m src.chatbot
+python -m src.chatbot [--model MODEL] [--temperature FLOAT] [--history-file PATH]
 ```
 
 Run the test suite to verify everything works as expected:

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,10 +19,10 @@ This directory collects detailed guides for setting up and running the example c
 
 ## Usage Example
 
-Start an interactive session by running the chatbot module directly:
+Start an interactive session by running the chatbot module directly. Command-line options let you configure the model, temperature, and store history in a file:
 
 ```bash
-python -m src.chatbot
+python -m src.chatbot [--model MODEL] [--temperature FLOAT] [--history-file PATH]
 ```
 
 Each prompt you enter is sent to the API and the assistant responds. Submit an empty line at the `You:` prompt to end the conversation.


### PR DESCRIPTION
## Summary
- extend `chatbot.py` with argparse CLI
- support storing/loading conversation history from a file
- document new `--model`, `--temperature`, and `--history-file` options in README and docs

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_687130cd7680832ab5295bca9b2fac7f