### PR TITLE
Add system message and max tokens options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ This repository contains a simple example project demonstrating how to integrate
 
 ## Running the Code
 
-Once you have installed the dependencies and set your API key, start the chatbot interactively. You can optionally choose the model, adjust the temperature, and
-store the conversation in a file. The session continues until you submit an empty line to exit:
+Once you have installed the dependencies and set your API key, start the chatbot interactively. You can optionally choose the model, adjust the temperature, supply an initial system message, limit the length of responses, and store the conversation in a file. The session continues until you submit an empty line to exit:
 
 ```
 python -m src.chatbot [--model MODEL] [--temperature FLOAT] [--history-file PATH]
+                          [--system-message TEXT] [--max-tokens INT]
 ```
 
 Run the test suite to verify everything works as expected:

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,10 +20,11 @@ This directory collects detailed guides for setting up and running the example c
 
 ## Usage Example
 
-Start an interactive session by running the chatbot module directly. Command-line options let you configure the model, temperature, and store history in a file:
+Start an interactive session by running the chatbot module directly. Command-line options let you configure the model, temperature, provide an initial system message, limit the response length, and store history in a file:
 
 ```bash
 python -m src.chatbot [--model MODEL] [--temperature FLOAT] [--history-file PATH]
+                         [--system-message TEXT] [--max-tokens INT]
 ```
 
 Each prompt you enter is sent to the API and the assistant responds. Submit an empty line at the `You:` prompt to end the conversation.

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -48,6 +48,26 @@ class ChatbotTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             chatbot.ask([{"role": "user", "content": "Hello"}])
 
+    def test_max_tokens_argument(self):
+        os.environ["OPENAI_API_KEY"] = "dummy-key"
+
+        captured: dict = {}
+
+        def capture_call(**kwargs):
+            captured.update(kwargs)
+
+            class DummyResponse:
+                def __init__(self):
+                    self.choices = [types.SimpleNamespace(message={"content": "hi"})]
+
+            return DummyResponse()
+
+        openai = sys.modules['openai']
+        openai.ChatCompletion = types.SimpleNamespace(create=capture_call)
+
+        chatbot.ask([{"role": "user", "content": "Hi"}], max_tokens=42)
+        self.assertEqual(captured.get("max_tokens"), 42)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `ask()` to support a `max_tokens` parameter
- allow specifying a system message and max tokens in the CLI
- document new CLI options
- cover new behaviour in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713db57714832aaf196aadcf72afc8